### PR TITLE
GSM: the new version of libmbd provides gradients

### DIFF
--- a/prog/dftb+/prg_dftb/main.F90
+++ b/prog/dftb+/prg_dftb/main.F90
@@ -4121,7 +4121,9 @@ contains
   #:if WITH_MBD
     if (allocated(mbDispersion)) then
       call mbDispersion%get_gradients(tmpDerivs)
-      tmpDerivs = -tmpDerivs
+      !> GSM: whereas the old mbd module returned forces instead of gradients,
+      !       the new one does return gradients. Thus the sign is right this time!
+      !> tmpDerivs = -tmpDerivs
       if (tIoProc) then
         write(stdOut,*) '!!!!!!!!!!!!!!!CALCULATING MBD GRADIENTS!!!!!!!!!!!!!!!!'
         write(stdOut,*) tmpDerivs(:, :)


### PR DESCRIPTION
Hi Jan,
as mentioned in the email just shortly before I think we again have a sign error in the forces between dftbplus and libmbd. Could it be that you switched from providing forces in an early version of the mbd implementation to gradients in the new libmbd? I stumbled over some forces pointing in the wrong direction and inconsistencies in numerical vs. analytical forces. Thus I investigated and it seems to me the new libmbd does indeed provide gradients (= -forces).
Cheers,
Mitch